### PR TITLE
Django 2.0.13 Additional Fix

### DIFF
--- a/coupons/migrations/0003_auto_20150416_0617.py
+++ b/coupons/migrations/0003_auto_20150416_0617.py
@@ -28,7 +28,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='coupon',
             name='campaign',
-            field=models.ForeignKey(related_name=b'coupons', verbose_name='Campaign', blank=True, to='coupons.Campaign', null=True, on_delete=models.CASCADE),
+            field=models.ForeignKey(related_name='coupons', verbose_name='Campaign', blank=True, to='coupons.Campaign', null=True, on_delete=models.CASCADE),
             preserve_default=True,
         ),
         migrations.AlterField(


### PR DESCRIPTION
Switched a byte related_name in the migrations file to a string. This caused an error when running migrations in Django 2.0.13.